### PR TITLE
Add interactive films index page with video thumbnails

### DIFF
--- a/src/pages/films.astro
+++ b/src/pages/films.astro
@@ -1,9 +1,163 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { films, getFilmThumbnail } from '../data/films.js';
+
 const pageTitle = "Films";
+
+// Transform film data for display
+const filmsWithThumbnails = films.map(film => ({
+  ...film,
+  thumbnail: getFilmThumbnail(film.slug)
+}));
 ---
 
 <BaseLayout pageTitle={pageTitle}>
-	<h1>{pageTitle}</h1>
-	<p>Coming soon...</p>
+	<div class="films-grid">
+		{filmsWithThumbnails.map(film => (
+			<a href={`/mywebsite/films/${film.slug}`} class="film-card">
+				<div class="film-thumbnail-container">
+					<video 
+						class="film-thumbnail"
+						src={film.thumbnail}
+						muted
+						preload="metadata"
+						playsinline
+						disablepictureinpicture
+						crossorigin="anonymous"
+						data-film={film.slug}
+					></video>
+				</div>
+				<h3 class="film-title">{film.name}</h3>
+			</a>
+		))}
+	</div>
 </BaseLayout>
+
+<style>
+	.films-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+		gap: 2rem;
+		margin-top: 1rem;
+	}
+
+	.film-card {
+		text-decoration: none;
+		color: inherit;
+		transition: transform 0.2s;
+		display: block;
+	}
+
+
+	.film-thumbnail-container {
+		width: 100%;
+		height: 300px;
+		position: relative;
+		overflow: hidden;
+	}
+
+	.film-thumbnail {
+		width: 100%;
+		height: 100%;
+		object-fit: contain;
+		object-position: center bottom;
+		cursor: pointer;
+	}
+
+	.film-title {
+		margin: 0.5rem 0 0 0;
+		font-size: 1rem;
+		color: var(--text-primary);
+		text-align: center;
+	}
+
+	@media (max-width: 768px) {
+		.films-grid {
+			grid-template-columns: 1fr;
+			gap: 2rem;
+		}
+		
+		.film-thumbnail-container {
+			height: 250px;
+		}
+	}
+
+	@media (min-width: 769px) and (max-width: 1024px) {
+		.films-grid {
+			grid-template-columns: repeat(2, 1fr);
+		}
+	}
+
+	@media (min-width: 1025px) {
+		.films-grid {
+			grid-template-columns: repeat(3, 1fr);
+		}
+	}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const videos = document.querySelectorAll('.film-thumbnail');
+  console.log('Found videos:', videos.length);
+  
+  videos.forEach((video, index) => {
+    console.log(`Video ${index + 1} src:`, video.src);
+    
+    // Safari-specific: Force load after a small delay
+    setTimeout(() => {
+      video.load();
+    }, 100);
+    
+    video.addEventListener('loadstart', () => {
+      console.log(`Video ${index + 1} started loading`);
+    });
+    
+    video.addEventListener('loadedmetadata', () => {
+      console.log(`Video ${index + 1} metadata loaded`);
+    });
+    
+    video.addEventListener('error', (e) => {
+      console.error(`Video ${index + 1} error:`, e, video.error);
+    });
+  });
+  
+  // Only enable hover video functionality on desktop (non-touch devices)
+  const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+  console.log('Is touch device:', isTouchDevice);
+  
+  if (!isTouchDevice) {
+    videos.forEach(video => {
+      const filmCard = video.closest('.film-card');
+      
+      filmCard.addEventListener('mouseenter', () => {
+        console.log('Mouse enter, video readyState:', video.readyState, 'ended:', video.ended);
+        // Only play if video hasn't ended
+        if (!video.ended) {
+          if (video.readyState >= 2) { // HAVE_CURRENT_DATA
+            video.play().catch(err => console.log('Video play failed:', err));
+          } else {
+            // Wait for metadata to load, then play
+            video.addEventListener('loadedmetadata', () => {
+              if (!video.ended) {
+                video.play().catch(err => console.log('Video play failed:', err));
+              }
+            }, { once: true });
+          }
+        }
+      });
+      
+      filmCard.addEventListener('mouseleave', () => {
+        if (!video.ended) {
+          video.pause();
+        }
+        // Keep video at current frame (don't reset to 0)
+      });
+      
+      // Handle video end - keep at last frame
+      video.addEventListener('ended', () => {
+        // Video will naturally stay at last frame
+      });
+    });
+  }
+});
+</script>


### PR DESCRIPTION
## Summary
- Implement interactive films index page with hover-to-play video thumbnails
- Add responsive grid layout matching photographs page design
- Include Safari compatibility fixes and mobile optimization

## Changes Made
- **Grid layout**: Responsive grid that adapts to screen size (1/2/3 columns)
- **Video thumbnails**: Hover-to-play functionality for desktop users
- **Smart playback**: Videos resume from paused position and stay at last frame when ended
- **Mobile optimization**: Static video thumbnails for touch devices
- **Safari compatibility**: Added crossorigin attribute and explicit load() calls
- **Clean interaction**: Removed hover transform effects for smooth video playback

## Technical Details
- Videos use `object-fit: contain` and `object-position: center bottom` for consistent display
- Touch device detection prevents hover functionality on mobile
- Video error handling and loading state management
- Preload metadata for faster initial display

## Test plan
- [x] Verify desktop hover-to-play functionality works
- [x] Test mobile displays static video thumbnails
- [x] Confirm Safari video loading and playback
- [x] Check responsive grid layout across screen sizes
- [x] Validate video pause/resume behavior

🤖 Generated with [Claude Code](https://claude.ai/code)